### PR TITLE
Add Subjects Modal

### DIFF
--- a/src/components/Modals/Subjects/Subjects.js
+++ b/src/components/Modals/Subjects/Subjects.js
@@ -1,17 +1,21 @@
 import React from 'react'
-import { Box, Button, Image, Text } from 'grommet'
-import { Close, FormNext, FormPrevious } from 'grommet-icons'
+import { Anchor, Box, Button, Image, Text } from 'grommet'
+import { Close } from 'grommet-icons'
 import { number } from 'prop-types'
 import { PlainButton } from '@zooniverse/react-components'
 import Map from 'images/satellite_map.png'
 import styled from 'styled-components'
+
+const Neuton = styled(Text)`
+  font-family: Neuton;
+`
 
 const StyledText = styled(Text)`
   vertical-align: middle;
 `
 
 const mockSubjects = new Array(19)
-mockSubjects.fill({ alt: 'Falkland Islands Map', src: Map })
+mockSubjects.fill({ alt: 'Falkland Islands Map', link: '#', src: Map })
 
 const chunk = (arr, size) => {
   return Array.from(
@@ -28,13 +32,14 @@ export default function Subjects ({ subjects = mockSubjects }) {
   return (
     <Box
       border
+      elevation='small'
       gap='xsmall'
       height='25em'
       pad='small'
       width='medium'
     >
       <Box direction='row' justify='between'>
-        <Text>Associated subjects ({subjects.length})</Text>
+        <Text color='kelp'>Associated subjects ({subjects.length})</Text>
         <PlainButton
           icon={<Close color='black' size='small' />}
           onClick={() => console.log('Close the modal')}
@@ -42,7 +47,7 @@ export default function Subjects ({ subjects = mockSubjects }) {
           reverse
         />
       </Box>
-      <Text>Click a subject to view it on Zooniverse Talk</Text>
+      <Neuton>Click a subject to view it on Zooniverse Talk</Neuton>
       <Box
         direction='row'
         justify='between'
@@ -57,7 +62,13 @@ export default function Subjects ({ subjects = mockSubjects }) {
               margin={{ bottom: 'xsmall' }}
               height='5.5em'
             >
-              <Image fit='contain' src={subject.src} />
+              <Anchor href={subject.link}>
+                <Image
+                  fit='contain'
+                  src={subject.src}
+                  width='100%'
+                />
+              </Anchor>
             </Box>
           )
         })}
@@ -68,6 +79,7 @@ export default function Subjects ({ subjects = mockSubjects }) {
         margin={{ horizontal: 'auto', top: 'auto' }}
       >
         <Button
+          disabled={subjectIndex === 0}
           label={<StyledText size='0.5em'>&#9664;</StyledText>}
           onClick={() => changeSubjectIndex(0)}
           plain
@@ -81,6 +93,7 @@ export default function Subjects ({ subjects = mockSubjects }) {
           )
         })}
         <Button
+          disabled={subjectIndex === lastIndex}
           label={<StyledText size='0.5em'>&#9654;</StyledText>}
           onClick={() => changeSubjectIndex(lastIndex)}
           plain

--- a/src/components/Modals/Subjects/Subjects.js
+++ b/src/components/Modals/Subjects/Subjects.js
@@ -1,0 +1,10 @@
+import React from 'react'
+import { Box, Text } from 'grommet'
+
+export default function Subjects () {
+  return (
+    <Box>
+      <Text>Hello World</Text>
+    </Box>
+  )
+}

--- a/src/components/Modals/Subjects/Subjects.js
+++ b/src/components/Modals/Subjects/Subjects.js
@@ -81,7 +81,7 @@ export default function Subjects ({ subjects = mockSubjects }) {
         <Button
           disabled={subjectIndex === 0}
           label={<StyledText size='0.5em'>&#9664;</StyledText>}
-          onClick={() => changeSubjectIndex(0)}
+          onClick={() => changeSubjectIndex(subjectIndex - 1)}
           plain
         />
         {chunkedSubjects.map((subj, i) => {
@@ -95,7 +95,7 @@ export default function Subjects ({ subjects = mockSubjects }) {
         <Button
           disabled={subjectIndex === lastIndex}
           label={<StyledText size='0.5em'>&#9654;</StyledText>}
-          onClick={() => changeSubjectIndex(lastIndex)}
+          onClick={() => changeSubjectIndex(subjectIndex + 1)}
           plain
         />
       </Box>

--- a/src/components/Modals/Subjects/Subjects.js
+++ b/src/components/Modals/Subjects/Subjects.js
@@ -87,7 +87,7 @@ export default function Subjects ({ subjects = mockSubjects }) {
         {chunkedSubjects.map((subj, i) => {
           const char = i === subjectIndex ? `\u25CF` : `\u25CB`
           return (
-            <Button onClick={() => changeSubjectIndex(i)}>
+            <Button key={`SUBJECTS_${i}`} onClick={() => changeSubjectIndex(i)}>
              {char}
             </Button>
           )

--- a/src/components/Modals/Subjects/Subjects.js
+++ b/src/components/Modals/Subjects/Subjects.js
@@ -1,10 +1,95 @@
 import React from 'react'
-import { Box, Text } from 'grommet'
+import { Box, Button, Image, Text } from 'grommet'
+import { Close, FormNext, FormPrevious } from 'grommet-icons'
+import { number } from 'prop-types'
+import { PlainButton } from '@zooniverse/react-components'
+import Map from 'images/satellite_map.png'
+import styled from 'styled-components'
 
-export default function Subjects () {
+const StyledText = styled(Text)`
+  vertical-align: middle;
+`
+
+const mockSubjects = new Array(19)
+mockSubjects.fill({ alt: 'Falkland Islands Map', src: Map })
+
+const chunk = (arr, size) => {
+  return Array.from(
+    { length: Math.ceil(arr.length / size) },
+    (v, i) => arr.slice(i * size, i * size + size)
+  )
+}
+
+export default function Subjects ({ subjects = mockSubjects }) {
+  const [subjectIndex, changeSubjectIndex] = React.useState(0)
+  const chunkedSubjects = chunk(subjects, 9)
+  const lastIndex = chunkedSubjects.length - 1
+
   return (
-    <Box>
-      <Text>Hello World</Text>
+    <Box
+      border
+      gap='xsmall'
+      height='25em'
+      pad='small'
+      width='medium'
+    >
+      <Box direction='row' justify='between'>
+        <Text>Associated subjects ({subjects.length})</Text>
+        <PlainButton
+          icon={<Close color='black' size='small' />}
+          onClick={() => console.log('Close the modal')}
+          text='Close'
+          reverse
+        />
+      </Box>
+      <Text>Click a subject to view it on Zooniverse Talk</Text>
+      <Box
+        direction='row'
+        justify='between'
+        width='medium'
+        wrap
+      >
+        {chunkedSubjects[subjectIndex].map((subject, i) => {
+          return (
+            <Box
+              key={`SUBJECTS_${i}`}
+              basis='30%'
+              margin={{ bottom: 'xsmall' }}
+              height='5.5em'
+            >
+              <Image fit='contain' src={subject.src} />
+            </Box>
+          )
+        })}
+      </Box>
+      <Box
+        direction='row'
+        gap='xxsmall'
+        margin={{ horizontal: 'auto', top: 'auto' }}
+      >
+        <Button
+          label={<StyledText size='0.5em'>&#9664;</StyledText>}
+          onClick={() => changeSubjectIndex(0)}
+          plain
+        />
+        {chunkedSubjects.map((subj, i) => {
+          const char = i === subjectIndex ? `\u25CF` : `\u25CB`
+          return (
+            <Button onClick={() => changeSubjectIndex(i)}>
+             {char}
+            </Button>
+          )
+        })}
+        <Button
+          label={<StyledText size='0.5em'>&#9654;</StyledText>}
+          onClick={() => changeSubjectIndex(lastIndex)}
+          plain
+        />
+      </Box>
     </Box>
   )
+}
+
+Subjects.propTypes = {
+  count: number
 }

--- a/src/components/Modals/Subjects/Subjects.spec.js
+++ b/src/components/Modals/Subjects/Subjects.spec.js
@@ -1,0 +1,10 @@
+import React from 'react'
+import Subjects from './Subjects'
+import { shallow } from 'enzyme'
+
+describe('Component > Subjects', function () {
+  it('should render without crashing', () => {
+    const wrapper = shallow(<Subjects />);
+    expect(wrapper).toBeDefined()
+  });
+})

--- a/src/components/Modals/Subjects/Subjects.spec.js
+++ b/src/components/Modals/Subjects/Subjects.spec.js
@@ -1,10 +1,45 @@
 import React from 'react'
-import Subjects from './Subjects'
 import { shallow } from 'enzyme'
+import { Button, Image } from 'grommet'
+import Subjects from './Subjects'
 
-describe('Component > Subjects', function () {
+describe('Component > Subjects', () => {
+  let wrapper
+
   it('should render without crashing', () => {
-    const wrapper = shallow(<Subjects />);
+    wrapper = shallow(<Subjects />);
     expect(wrapper).toBeDefined()
   });
+
+  describe('navigation controls', () => {
+    it('should go to the last page', () => {
+      let lastBtn = wrapper.find(Button).last()
+      lastBtn.simulate('click')
+      let images = wrapper.find(Image)
+      expect(images.length).toBe(1)
+      lastBtn = wrapper.find(Button).last()
+      expect(lastBtn.props().disabled).toBeTruthy()
+    })
+
+    it('should go to the first page', () => {
+      let firstBtn = wrapper.find(Button).first()
+      firstBtn.simulate('click')
+      let images = wrapper.find(Image)
+      expect(images.length).toBe(9)
+      firstBtn = wrapper.find(Button).first()
+      expect(firstBtn.props().disabled).toBeTruthy()
+    })
+
+    it('should go to the nth page', () => {
+      let nthBtn = wrapper.find(Button).at(2)
+      nthBtn.simulate('click')
+      let images = wrapper.find(Image)
+      expect(images.length).toBe(9)
+
+      const firstBtn = wrapper.find(Button).first()
+      const lastBtn = wrapper.find(Button).last()
+      expect(firstBtn.props().disabled).toBeFalsy()
+      expect(lastBtn.props().disabled).toBeFalsy()
+    })
+  })
 })

--- a/src/components/Modals/Subjects/Subjects.spec.js
+++ b/src/components/Modals/Subjects/Subjects.spec.js
@@ -12,13 +12,13 @@ describe('Component > Subjects', () => {
   });
 
   describe('navigation controls', () => {
-    it('should go to the last page', () => {
+    it('should go to the next page', () => {
       let lastBtn = wrapper.find(Button).last()
       lastBtn.simulate('click')
       let images = wrapper.find(Image)
-      expect(images.length).toBe(1)
+      expect(images.length).toBe(9)
       lastBtn = wrapper.find(Button).last()
-      expect(lastBtn.props().disabled).toBeTruthy()
+      expect(lastBtn.props().disabled).toBeFalsy()
     })
 
     it('should go to the first page', () => {

--- a/src/components/Modals/Subjects/index.js
+++ b/src/components/Modals/Subjects/index.js
@@ -1,0 +1,1 @@
+export { default } from './Subjects'

--- a/src/stories/Subjects.stories.js
+++ b/src/stories/Subjects.stories.js
@@ -1,0 +1,12 @@
+import React from 'react';
+import { storiesOf } from '@storybook/react';
+import Subjects from '../components/Modals/Subjects'
+import { Grommet } from 'grommet'
+import theme from 'theme'
+
+storiesOf('Subjects Modal', module)
+  .add('Default', () => (
+    <Grommet theme={theme}>
+      <Subjects />
+    </Grommet>
+  ))

--- a/src/theme.js
+++ b/src/theme.js
@@ -7,7 +7,7 @@ const brand = '#113E3B'
 const theme = {
   global: {
     colors: {
-      border: 'black',
+      border: brand,
       brand,
       kelp: '#113E3B',
       indiglo: '#EEFEC0',


### PR DESCRIPTION
This PR adds the [subjects modal](https://projects.invisionapp.com/d/main#/console/19544062/419878186/preview) to the storybook, which will later be added to the `/map` route. 

Right now, I'm mainly focused on MVP. No fancy step through animation like we use in PFE. After this merges, I'll abstract all three modals into a modal wrapper using a Grommet `Layer` component to remove some redundancy.

Also, I realize the "close" button here is a bit different from the design. I'm using the `PlainButton` from the shared components library, and a [change](https://github.com/zooniverse/front-end-monorepo/issues/1752) there is needed to allow overwriting the default color.

![Screen Shot 2020-08-14 at 10 29 09 AM](https://user-images.githubusercontent.com/14099077/90272512-24275300-de23-11ea-8f07-4a877bb04935.png)
