### PR TITLE
Add missing alt tags to images

### DIFF
--- a/src/components/MapDetail/components/AssociatedSubjects/AssociatedSubjects.js
+++ b/src/components/MapDetail/components/AssociatedSubjects/AssociatedSubjects.js
@@ -26,7 +26,7 @@ export default function AssociatedSubjects() {
           reverse
         />
       </Box>
-      <Image fit='contain' src={Subjects} />
+      <Image alt='Subjects associated with this location' fit='contain' src={Subjects} />
     </Box>
   )
 }

--- a/src/components/Modals/Metadata/Metadata.js
+++ b/src/components/Modals/Metadata/Metadata.js
@@ -50,7 +50,7 @@ export default function Metadata() {
         border={{ color: 'kelp' }}
         height={{ max: '16rem' }}
       >
-        <Image fit='contain' src={Satellite} />
+        <Image alt='Satellite Map of Falklands' fit='contain' src={Satellite} />
       </Box>
       <Box overflow={{ vertical: 'auto' }}>
         <StyledDataTable

--- a/src/components/Modals/Subjects/Subjects.js
+++ b/src/components/Modals/Subjects/Subjects.js
@@ -64,6 +64,7 @@ export default function Subjects ({ subjects = mockSubjects }) {
             >
               <Anchor href={subject.link}>
                 <Image
+                  alt={subject.alt}
                   fit='contain'
                   src={subject.src}
                   width='100%'

--- a/src/screens/MapPage/components/SidePanel/SidePanel.js
+++ b/src/screens/MapPage/components/SidePanel/SidePanel.js
@@ -38,7 +38,12 @@ export default function SidePanel() {
       width='15rem'
     >
       <Box gap='xsmall' margin={{ bottom: 'small' }} width='10rem'>
-        <Image fit='contain' margin={{ right: 'auto' }} src={Logo} />
+        <Image
+          alt='Floating Forests logo'
+          fit='contain'
+          margin={{ right: 'auto' }}
+          src={Logo}
+        />
         <StyledText color='kelp' size='xlarge'>
           Falkland Islands
         </StyledText>
@@ -59,7 +64,7 @@ export default function SidePanel() {
           color='kelp'
           gap='xsmall'
           hoverIndicator={{ color: 'indiglo' }}
-          icon={<Image src={RectangleIcon} />}
+          icon={<Image alt='Rectangle tool icon' src={RectangleIcon} />}
           label={<Uppercase size='xsmall'>Rectangle Tool</Uppercase>}
           plain
         />
@@ -79,7 +84,7 @@ export default function SidePanel() {
 
       <Box border={{ color: 'kelp', side: 'top' }} gap='xsmall'>
         <Text color='kelp' margin={{ top: 'small' }}>World map</Text>
-        <Image src={Map} />
+        <Image alt='Current location on a world map' src={Map} />
       </Box>
     </Box>
   )


### PR DESCRIPTION
Several images in the app are missing alt tags, which lowers accessibility. This PR adds a few missing tags.