### PR TITLE
Remove the ability to choose locations

### DIFF
--- a/src/screens/Home/components/ChooseLocation/ChooseLocation.js
+++ b/src/screens/Home/components/ChooseLocation/ChooseLocation.js
@@ -13,8 +13,8 @@ const StyledText = styled(Text)`
 
 const OPTIONS = [
   { label: 'Falkland Islands', map: Map},
-  { label: 'Baja, California', map: Map},
-  { label: 'Tasmania, Australia', map: Map}
+  // { label: 'Baja, California', map: Map},
+  // { label: 'Tasmania, Australia', map: Map}
 ]
 
 function ChooseLocation() {

--- a/src/screens/MapPage/components/SidePanel/SidePanel.js
+++ b/src/screens/MapPage/components/SidePanel/SidePanel.js
@@ -11,7 +11,7 @@ import RectangleIcon from 'images/rectangle_icon.svg'
 import Map from 'images/map.png'
 import styled, { css } from 'styled-components'
 import { bool, func } from 'prop-types'
-import LocationDrop from '../LocationDrop'
+// import LocationDrop from '../LocationDrop'
 
 const Uppercase = styled(Text)`
   text-transform: uppercase;
@@ -48,7 +48,7 @@ export default function SidePanel({ changeDrawing = () => {}, isDrawing = false 
         <StyledText color='kelp' size='xlarge'>
           Falkland Islands
         </StyledText>
-        <LocationDrop />
+        {/* <LocationDrop /> */}
       </Box>
 
       <Box


### PR DESCRIPTION
For now, I commented out a couple spots in the code that allow the user to select a location. These spots can be uncommented once other locations open up, but for now we're only concerned with the Falklands. Screenshots below for changes.

<img width="500" alt="Screen Shot 2020-09-24 at 4 03 23 PM" src="https://user-images.githubusercontent.com/14099077/94200223-ab82d000-fe7f-11ea-91cc-f86c4e3c0935.png">
Falklands is the only option on the home page

<img width="207" alt="Screen Shot 2020-09-24 at 4 01 17 PM" src="https://user-images.githubusercontent.com/14099077/94200241-b9385580-fe7f-11ea-81d9-970921eb60a5.png">
I've removed the location selection drop from the side menu, which was originally above the "Getting Started" text.

[Original design](https://projects.invisionapp.com/d/main?origin=v7#/console/19544062/412564491/preview?scrollOffset=574.5)