### PR TITLE
Remove Math.absolute from getLocationDetails to reflect correct earth lat/lon coordinates

### DIFF
--- a/src/helpers/getLocationDetails.js
+++ b/src/helpers/getLocationDetails.js
@@ -28,7 +28,6 @@ function getLocationDetails(location, type = 'lat') {
     direction = type === 'lat' ? 'N' : 'E'
   }
 
-  location = Math.abs(location)
   let [degrees, minutes] = location.toString().split('.')
   minutes = minutes.substr(0,2)
   return { degrees, direction, minutes }

--- a/src/helpers/getLocationDetails.spec.js
+++ b/src/helpers/getLocationDetails.spec.js
@@ -33,12 +33,12 @@ describe('Helper > getLocationDetails', () => {
   }
 
   const expectedLatLocation = {
-    degrees: '51',
+    degrees: '-51',
     direction: 'S',
     minutes: '80',
   }
   const expectedLngLocation = {
-    degrees: '59',
+    degrees: '-59',
     direction: 'W',
     minutes: '42',
   }


### PR DESCRIPTION
Using Math.abs() in getLocationDetails was causing the center point in MapDetail to be incorrectly displayed. For example, 51°S 59°W instead of -51°S -59°W.