### PR TITLE
Refactor home page styling for mobile widths

### DIFF
--- a/src/screens/Home/Home.js
+++ b/src/screens/Home/Home.js
@@ -12,6 +12,20 @@ const StyledText = styled(Text)`
   font-family: Neuton;
 `
 
+const Relative = styled(Box)`
+  position: relative;
+`
+
+const AccentLine = styled(Box)`
+  position: absolute;
+  left: 0;
+  bottom: -50px;
+  height: 20vw;
+  min-height: 200px;
+  width: 1px;
+  background: #113e3b;
+`
+
 const Home = ({ screenSize }) => {
   const mobile = screenSize === 'small'
 
@@ -38,22 +52,26 @@ const Home = ({ screenSize }) => {
         </Box>
 
         <Box direction={mobile ? 'column' : 'row'}>
-          <Box basis='2/3' flex='grow' pad={mobile ? null : { right: 'medium' }}>
+          <Box
+            basis='2/3'
+            flex='grow'
+            pad={mobile ? null : { right: 'medium' }}
+          >
             <ChooseLocation />
           </Box>
-          <Box
+          <Relative
             basis='1/3'
-            border={mobile ? null : 'left'}
             flex='grow'
             gap='small'
             pad={mobile ? null : { left: 'medium' }}
           >
+            {!mobile && <AccentLine />}
             <StyledText size='1rem'>
               This project is a collaboration between Zooniverse-Adler
               Planetarium and the Floating Forests team.
             </StyledText>
             <Anchor href='#' label='Learn more' size='small' />
-          </Box>
+          </Relative>
         </Box>
       </Box>
     </Box>

--- a/src/screens/Home/Home.js
+++ b/src/screens/Home/Home.js
@@ -1,7 +1,7 @@
 import React from 'react'
 import { Anchor, Box, Text } from 'grommet'
 import MappingVizLogo from 'components/MappingVizLogo'
-import styled from 'styled-components'
+import styled, { withTheme, css } from 'styled-components'
 import ChooseLocation from './components/ChooseLocation'
 import {
   ZooniverseLogotype,
@@ -23,7 +23,10 @@ const AccentLine = styled(Box)`
   height: 20vw;
   min-height: 200px;
   width: 1px;
-  background: #113e3b;
+  ${props =>
+    css`
+      background: ${props.theme.global.colors.brand};
+    `}
 `
 
 const Home = ({ screenSize }) => {
@@ -78,4 +81,4 @@ const Home = ({ screenSize }) => {
   )
 }
 
-export default withResponsiveContext(Home)
+export default withTheme(withResponsiveContext(Home))

--- a/src/screens/Home/Home.js
+++ b/src/screens/Home/Home.js
@@ -23,24 +23,22 @@ const Home = ({ screenSize }) => {
         border={{
           color: 'kelp',
           side: 'right',
-          size: mobile ? 'small' : 'large',
+          size: mobile ? 'medium' : 'large',
         }}
       />
 
-      <Box gap='medium' justify={mobile ? '' : 'between'}>
-        <Box
-          margin={{ horizontal: 'medium', top: 'large' }}
-          width={{ max: '40rem' }}
-        >
+      <Box
+        gap='medium'
+        justify={mobile ? '' : 'between'}
+        margin={mobile ? 'medium' : 'large'}
+      >
+        <Box width={{ max: '40rem' }}>
           <ZooniverseLogotype />
           <MappingVizLogo id='MappingVizualizationsLogo' />
         </Box>
 
-        <Box
-          direction={mobile ? 'column' : 'row'}
-          margin={{ horizontal: 'medium' }}
-        >
-          <Box basis='2/3' flex='grow' margin={{ right: 'xsmall' }}>
+        <Box direction={mobile ? 'column' : 'row'}>
+          <Box basis='2/3' flex='grow' pad={mobile ? null : { right: 'medium' }}>
             <ChooseLocation />
           </Box>
           <Box
@@ -48,7 +46,7 @@ const Home = ({ screenSize }) => {
             border={mobile ? null : 'left'}
             flex='grow'
             gap='small'
-            pad={mobile ? '' : 'medium'}
+            pad={mobile ? null : { left: 'medium' }}
           >
             <StyledText size='1rem'>
               This project is a collaboration between Zooniverse-Adler

--- a/src/screens/Home/Home.js
+++ b/src/screens/Home/Home.js
@@ -3,22 +3,31 @@ import { Anchor, Box, Text } from 'grommet'
 import MappingVizLogo from 'components/MappingVizLogo'
 import styled from 'styled-components'
 import ChooseLocation from './components/ChooseLocation'
-import { ZooniverseLogotype } from '@zooniverse/react-components'
+import {
+  ZooniverseLogotype,
+  withResponsiveContext,
+} from '@zooniverse/react-components'
 
 const StyledText = styled(Text)`
   font-family: Neuton;
 `
 
-export default function Home() {
+const Home = ({ screenSize }) => {
+  const mobile = screenSize === 'small'
+
   return (
     <Box background='sand' direction='row' height={{ min: '100%' }}>
       <Box
         basis='1/4'
         background={{ image: 'url(/kelp.png)' }}
-        border={{ color: 'kelp', side: 'right', size: 'large' }}
+        border={{
+          color: 'kelp',
+          side: 'right',
+          size: mobile ? 'small' : 'large',
+        }}
       />
 
-      <Box gap='medium' justify='between'>
+      <Box gap='medium' justify={mobile ? '' : 'between'}>
         <Box
           margin={{ horizontal: 'medium', top: 'large' }}
           width={{ max: '40rem' }}
@@ -28,37 +37,29 @@ export default function Home() {
         </Box>
 
         <Box
-          direction='row'
+          direction={mobile ? 'column' : 'row'}
           margin={{ horizontal: 'medium' }}
-          width={{ max: '50rem' }}
-          wrap
         >
-          <Box
-            basis='3/4'
-            flex='grow'
-            margin={{ right: 'xsmall' }}
-          >
+          <Box basis='2/3' flex='grow' margin={{ right: 'xsmall' }}>
             <ChooseLocation />
           </Box>
           <Box
-            basis='10rem'
-            border='left'
+            basis='1/3'
+            border={mobile ? null : 'left'}
             flex='grow'
             gap='small'
-            pad='medium'
+            pad={mobile ? '' : 'medium'}
           >
             <StyledText size='1rem'>
-              This project is a collaboration between Zooniverse-Adler Planetarium
-              and the Floating Forests team.
+              This project is a collaboration between Zooniverse-Adler
+              Planetarium and the Floating Forests team.
             </StyledText>
-            <Anchor
-              href='#'
-              label='Learn more'
-              size='small'
-            />
+            <Anchor href='#' label='Learn more' size='small' />
           </Box>
         </Box>
       </Box>
     </Box>
   )
 }
+
+export default withResponsiveContext(Home)

--- a/src/screens/Home/Home.js
+++ b/src/screens/Home/Home.js
@@ -43,7 +43,7 @@ const Home = ({ screenSize }) => {
 
       <Box
         gap='medium'
-        justify={mobile ? '' : 'between'}
+        justify={mobile ? 'start' : 'between'}
         margin={mobile ? 'medium' : 'large'}
       >
         <Box width={{ max: '40rem' }}>

--- a/src/screens/Home/components/ChooseLocation/ChooseLocation.js
+++ b/src/screens/Home/components/ChooseLocation/ChooseLocation.js
@@ -1,12 +1,8 @@
 import React from 'react'
 import { Box, Text } from 'grommet'
 import styled from 'styled-components'
-import {
-  withThemeContext,
-  withResponsiveContext,
-} from '@zooniverse/react-components'
+import { withThemeContext } from '@zooniverse/react-components'
 import Map from 'images/hover-map.png'
-import ResponsiveImage from 'components/ResponsiveImage'
 import MapLabel from './components/MapLabel'
 import theme from './theme'
 
@@ -20,14 +16,10 @@ const OPTIONS = [
   // { label: 'Tasmania, Australia', map: Map}
 ]
 
-const ChooseLocation = ({ screenSize }) => {
-  const mobile = screenSize === 'small'
-
-  const [activeLocation, setActiveLocation] = React.useState(null)
-
+const ChooseLocation = () => {
   return (
     <Box direction='row'>
-      <Box>
+      <Box margin={{ bottom: 'small' }}>
         <StyledText size='1.25rem' margin={{ bottom: 'small' }}>
           Choose a location to begin
         </StyledText>
@@ -36,26 +28,13 @@ const ChooseLocation = ({ screenSize }) => {
             <MapLabel
               key={location.label}
               location={location}
-              onActivate={setActiveLocation}
             />
           )
         })}
       </Box>
-      {!mobile && (
-        <Box align='center' flex='grow' pad='xxsmall'>
-          {activeLocation && (
-            <ResponsiveImage
-              a11yTitle={`Map of ${activeLocation.label}`}
-              border
-              height='8em'
-              src={activeLocation.map}
-            />
-          )}
-        </Box>
-      )}
     </Box>
   )
 }
 
-export default withResponsiveContext(withThemeContext(ChooseLocation, theme))
+export default withThemeContext(ChooseLocation, theme)
 export { ChooseLocation }

--- a/src/screens/Home/components/ChooseLocation/ChooseLocation.js
+++ b/src/screens/Home/components/ChooseLocation/ChooseLocation.js
@@ -1,7 +1,10 @@
 import React from 'react'
 import { Box, Text } from 'grommet'
 import styled from 'styled-components'
-import { withThemeContext } from '@zooniverse/react-components'
+import {
+  withThemeContext,
+  withResponsiveContext,
+} from '@zooniverse/react-components'
 import Map from 'images/hover-map.png'
 import ResponsiveImage from 'components/ResponsiveImage'
 import MapLabel from './components/MapLabel'
@@ -12,24 +15,20 @@ const StyledText = styled(Text)`
 `
 
 const OPTIONS = [
-  { label: 'Falkland Islands', map: Map},
+  { label: 'Falkland Islands', map: Map },
   // { label: 'Baja, California', map: Map},
   // { label: 'Tasmania, Australia', map: Map}
 ]
 
-function ChooseLocation() {
+const ChooseLocation = ({ screenSize }) => {
+  const mobile = screenSize === 'small'
+
   const [activeLocation, setActiveLocation] = React.useState(null)
 
   return (
-    <Box
-      direction='row'
-      wrap
-    >
-      <Box flex='grow'>
-        <StyledText
-          margin='xxsmall'
-          size='1.25rem'
-        >
+    <Box direction='row'>
+      <Box>
+        <StyledText size='1.25rem' margin={{ bottom: 'small' }}>
           Choose a location to begin
         </StyledText>
         {OPTIONS.map((location, i) => {
@@ -39,21 +38,24 @@ function ChooseLocation() {
               location={location}
               onActivate={setActiveLocation}
             />
-        )})}
+          )
+        })}
       </Box>
-      <Box align='center' flex='grow' pad='xxsmall'>
-        {activeLocation && (
-          <ResponsiveImage
-            a11yTitle={`Map of ${activeLocation.label}`}
-            border
-            height='8em'
-            src={activeLocation.map}
-          />
-        )}
-      </Box>
+      {!mobile && (
+        <Box align='center' flex='grow' pad='xxsmall'>
+          {activeLocation && (
+            <ResponsiveImage
+              a11yTitle={`Map of ${activeLocation.label}`}
+              border
+              height='8em'
+              src={activeLocation.map}
+            />
+          )}
+        </Box>
+      )}
     </Box>
   )
 }
 
-export default withThemeContext(ChooseLocation, theme)
+export default withResponsiveContext(withThemeContext(ChooseLocation, theme))
 export { ChooseLocation }

--- a/src/screens/Home/components/ChooseLocation/ChooseLocation.spec.js
+++ b/src/screens/Home/components/ChooseLocation/ChooseLocation.spec.js
@@ -1,8 +1,6 @@
 import React from 'react';
 import { shallow } from 'enzyme'
-import ResponsiveImage from 'components/ResponsiveImage'
 import { ChooseLocation } from './ChooseLocation';
-import MapLabel from './components/MapLabel'
 
 describe('Component > ChooseLocation', function () {
   let wrapper
@@ -14,14 +12,4 @@ describe('Component > ChooseLocation', function () {
   it('should render without crashing', () => {
     expect(wrapper).toBeDefined()
   });
-
-  describe('when activating a label', function () {
-    it('should show a map image', function () {
-      const label = wrapper.find(MapLabel).first()
-      label.props().onActivate({ label: 'California', map: 'test.png'})
-      wrapper.update()
-      const images = wrapper.find(ResponsiveImage)
-      expect(images.length).toBe(1)
-    })
-  })
 })

--- a/src/screens/Home/components/ChooseLocation/components/MapLabel.js
+++ b/src/screens/Home/components/ChooseLocation/components/MapLabel.js
@@ -35,7 +35,7 @@ const Relative = styled(Box)`
       left: 0;
       width: 100%;
       height: 1px;
-      background: #113e3b;
+      background: #113E3B;
     }
   }
 `

--- a/src/screens/Home/components/ChooseLocation/components/MapLabel.js
+++ b/src/screens/Home/components/ChooseLocation/components/MapLabel.js
@@ -16,7 +16,10 @@ export const StyledAnchor = styled(Anchor)`
     left: 0;
     width: 100%;
     height: 1px;
-    ${props => css`background: ${props.theme.global.colors.brand}`}
+    ${props =>
+      css`
+        background: ${props.theme.global.colors.brand};
+      `}
   }
 
   &:hover {
@@ -26,18 +29,26 @@ export const StyledAnchor = styled(Anchor)`
 
 const Relative = styled(Box)`
   position: relative;
-  
-  &:hover {
-    &::after {
-      content: '';
-      position: absolute;
-      bottom: 0;
-      left: 0;
-      width: 110%;
-      height: 1px;
-      ${props => css`background: ${props.theme.global.colors.brand}`}
-    }
-  }
+
+  ${props =>
+    props.mobile
+      ? null
+      : css`
+          &:hover {
+            &::after {
+              content: '';
+              position: absolute;
+              bottom: 0;
+              left: 0;
+              width: 110%;
+              height: 1px;
+              ${props =>
+                css`
+                  background: ${props.theme.global.colors.brand};
+                `}
+            }
+          }
+        `}
 `
 
 const Thumbnail = styled(Box)`
@@ -48,11 +59,13 @@ const Thumbnail = styled(Box)`
 `
 
 export const StyledImage = styled(Image)`
-  ${props => css`border: 1px solid ${props.theme.global.colors.brand}`}
+  ${props =>
+    css`
+      border: 1px solid ${props.theme.global.colors.brand};
+    `}
 `
 
-const MapLabel = ({ location, screenSize, theme }) => {
-  console.log(theme)
+const MapLabel = ({ location, screenSize }) => {
   const mobile = screenSize === 'small'
 
   const [isHovered, onHover] = React.useState(false)
@@ -67,7 +80,7 @@ const MapLabel = ({ location, screenSize, theme }) => {
   }
 
   return (
-    <Relative direction='row' margin={{ bottom: 'xsmall' }}>
+    <Relative direction='row' margin={{ bottom: 'xsmall' }} mobile={mobile}>
       <StyledAnchor
         href='/map'
         label={location.label}

--- a/src/screens/Home/components/ChooseLocation/components/MapLabel.js
+++ b/src/screens/Home/components/ChooseLocation/components/MapLabel.js
@@ -1,7 +1,7 @@
 import React from 'react'
 import { Anchor, Box, Image } from 'grommet'
 import styled, { css, withTheme } from 'styled-components'
-import { func, shape, string } from 'prop-types'
+import { shape, string } from 'prop-types'
 import { withResponsiveContext } from '@zooniverse/react-components'
 
 export const StyledAnchor = styled(Anchor)`
@@ -106,11 +106,7 @@ MapLabel.propTypes = {
     label: string,
     map: string,
   }).isRequired,
-  onActivate: func,
-}
-
-MapLabel.defaultProp = {
-  onActivate: () => {},
 }
 
 export default withTheme(withResponsiveContext(MapLabel))
+export { MapLabel }

--- a/src/screens/Home/components/ChooseLocation/components/MapLabel.js
+++ b/src/screens/Home/components/ChooseLocation/components/MapLabel.js
@@ -47,7 +47,7 @@ const Thumbnail = styled(Box)`
   transform: translateY(-50%);
 `
 
-const StyledImage = styled(Image)`
+export const StyledImage = styled(Image)`
   border: 1px solid #113E3B;
 `
 

--- a/src/screens/Home/components/ChooseLocation/components/MapLabel.js
+++ b/src/screens/Home/components/ChooseLocation/components/MapLabel.js
@@ -1,43 +1,72 @@
 import React from 'react'
-import { Anchor, Box } from 'grommet'
+import { Anchor, Box, Image } from 'grommet'
 import styled from 'styled-components'
 import { func, shape, string } from 'prop-types'
 import { withResponsiveContext } from '@zooniverse/react-components'
 
 export const StyledAnchor = styled(Anchor)`
   white-space: nowrap;
-  
-`
+  position: relative;
+  text-decoration: none;
 
-// refactor this as absolute positioned
-export const StyledHr = styled.hr`
-  border-top: 1px solid black;
-  margin: auto;
-  width: 100%;
+  &::after {
+    content: '';
+    position: absolute;
+    bottom: 0;
+    left: 0;
+    width: 100%;
+    height: 1px;
+    background: #113e3b;
+  }
+
+  &:hover {
+    text-decoration: none;
+  }
 `
 
 const Relative = styled(Box)`
   position: relative;
+  
+  &:hover {
+    &::after {
+      content: '';
+      position: absolute;
+      bottom: 0;
+      left: 0;
+      width: 100%;
+      height: 1px;
+      background: #113e3b;
+    }
+  }
 `
 
-const MapLabel = ({ location, onActivate, screenSize }) => {
+const Thumbnail = styled(Box)`
+  position: absolute;
+  left: 100%;
+  top: 50%;
+  transform: translateY(-50%);
+`
+
+const StyledImage = styled(Image)`
+  border: 1px solid #113E3B;
+`
+
+const MapLabel = ({ location, screenSize }) => {
   const mobile = screenSize === 'small'
 
   const [isHovered, onHover] = React.useState(false)
   const activate = () => {
     if (mobile) return
     onHover(true)
-    onActivate(location)
   }
 
   const deactivate = () => {
     if (mobile) return
     onHover(false)
-    onActivate(null)
   }
 
   return (
-    <Relative direction='row'>
+    <Relative direction='row' margin={{ bottom: 'xsmall' }}>
       <StyledAnchor
         href='/map'
         label={location.label}
@@ -45,9 +74,15 @@ const MapLabel = ({ location, onActivate, screenSize }) => {
         onFocus={activate}
         onMouseEnter={activate}
         onMouseLeave={deactivate}
-        margin={{ bottom: 'small' }}
       />
-      {isHovered && <StyledHr />}
+      {isHovered && !mobile && (
+        <Thumbnail>
+          <StyledImage
+            a11yTitle={`Map of ${location.label}`}
+            src={location.map}
+          />
+        </Thumbnail>
+      )}
     </Relative>
   )
 }

--- a/src/screens/Home/components/ChooseLocation/components/MapLabel.js
+++ b/src/screens/Home/components/ChooseLocation/components/MapLabel.js
@@ -1,6 +1,6 @@
 import React from 'react'
 import { Anchor, Box, Image } from 'grommet'
-import styled from 'styled-components'
+import styled, { css, withTheme } from 'styled-components'
 import { func, shape, string } from 'prop-types'
 import { withResponsiveContext } from '@zooniverse/react-components'
 
@@ -16,7 +16,7 @@ export const StyledAnchor = styled(Anchor)`
     left: 0;
     width: 100%;
     height: 1px;
-    background: #113e3b;
+    ${props => css`background: ${props.theme.global.colors.brand}`}
   }
 
   &:hover {
@@ -33,25 +33,26 @@ const Relative = styled(Box)`
       position: absolute;
       bottom: 0;
       left: 0;
-      width: 100%;
+      width: 110%;
       height: 1px;
-      background: #113E3B;
+      ${props => css`background: ${props.theme.global.colors.brand}`}
     }
   }
 `
 
 const Thumbnail = styled(Box)`
   position: absolute;
-  left: 100%;
+  left: 110%;
   top: 50%;
   transform: translateY(-50%);
 `
 
 export const StyledImage = styled(Image)`
-  border: 1px solid #113E3B;
+  ${props => css`border: 1px solid ${props.theme.global.colors.brand}`}
 `
 
-const MapLabel = ({ location, screenSize }) => {
+const MapLabel = ({ location, screenSize, theme }) => {
+  console.log(theme)
   const mobile = screenSize === 'small'
 
   const [isHovered, onHover] = React.useState(false)
@@ -99,4 +100,4 @@ MapLabel.defaultProp = {
   onActivate: () => {},
 }
 
-export default withResponsiveContext(MapLabel)
+export default withTheme(withResponsiveContext(MapLabel))

--- a/src/screens/Home/components/ChooseLocation/components/MapLabel.js
+++ b/src/screens/Home/components/ChooseLocation/components/MapLabel.js
@@ -2,37 +2,42 @@ import React from 'react'
 import { Anchor, Box } from 'grommet'
 import styled from 'styled-components'
 import { func, shape, string } from 'prop-types'
+import { withResponsiveContext } from '@zooniverse/react-components'
 
 export const StyledAnchor = styled(Anchor)`
-  padding: 0.5em;
   white-space: nowrap;
-
-  :focus, :hover {
-    background: white;
-    text-decoration: underline;
-  }
+  
 `
 
+// refactor this as absolute positioned
 export const StyledHr = styled.hr`
   border-top: 1px solid black;
   margin: auto;
   width: 100%;
 `
 
-export default function MapLabel({ location, onActivate }) {
+const Relative = styled(Box)`
+  position: relative;
+`
+
+const MapLabel = ({ location, onActivate, screenSize }) => {
+  const mobile = screenSize === 'small'
+
   const [isHovered, onHover] = React.useState(false)
   const activate = () => {
+    if (mobile) return
     onHover(true)
     onActivate(location)
   }
 
   const deactivate = () => {
+    if (mobile) return
     onHover(false)
     onActivate(null)
   }
 
   return (
-    <Box direction='row'>
+    <Relative direction='row'>
       <StyledAnchor
         href='/map'
         label={location.label}
@@ -40,20 +45,23 @@ export default function MapLabel({ location, onActivate }) {
         onFocus={activate}
         onMouseEnter={activate}
         onMouseLeave={deactivate}
+        margin={{ bottom: 'small' }}
       />
       {isHovered && <StyledHr />}
-    </Box>
+    </Relative>
   )
 }
 
 MapLabel.propTypes = {
   location: shape({
     label: string,
-    map: string
+    map: string,
   }).isRequired,
-  onActivate: func
+  onActivate: func,
 }
 
 MapLabel.defaultProp = {
-  onActivate: () => {}
+  onActivate: () => {},
 }
+
+export default withResponsiveContext(MapLabel)

--- a/src/screens/Home/components/ChooseLocation/components/MapLabel.spec.js
+++ b/src/screens/Home/components/ChooseLocation/components/MapLabel.spec.js
@@ -1,6 +1,8 @@
 import React from 'react'
 import { mount } from 'enzyme'
-import MapLabel, { StyledAnchor, StyledImage } from './MapLabel'
+import { MapLabel, StyledAnchor, StyledImage } from './MapLabel'
+import theme from '../../../../../theme'
+import { Grommet } from 'grommet'
 
 let wrapper
 
@@ -11,7 +13,10 @@ describe('Component > MapLabel', function () {
   }
 
   beforeEach(function () {
-    wrapper = mount(<MapLabel location={location} />)
+    wrapper = mount(<MapLabel location={location} />, {
+      wrappingComponent: Grommet,
+      wrappingComponentProps: { theme: theme },
+    })
   })
 
   it('should render without crashing', () => {

--- a/src/screens/Home/components/ChooseLocation/components/MapLabel.spec.js
+++ b/src/screens/Home/components/ChooseLocation/components/MapLabel.spec.js
@@ -1,44 +1,33 @@
-import React from 'react';
-import { shallow } from 'enzyme'
-import MapLabel, { StyledAnchor, StyledHr } from './MapLabel';
+import React from 'react'
+import { mount } from 'enzyme'
+import MapLabel, { StyledAnchor, StyledImage } from './MapLabel'
 
 let wrapper
 
 describe('Component > MapLabel', function () {
-  const onActivateSpy = jest.fn()
   const location = {
     label: 'Baja, California',
-    map: 'image.png'
+    map: 'image.png',
   }
 
   beforeEach(function () {
-    wrapper = shallow(
-      <MapLabel
-        location={location}
-        onActivate={onActivateSpy}
-      />);
+    wrapper = mount(<MapLabel location={location} />)
   })
-
-  afterEach(() => jest.clearAllMocks());
 
   it('should render without crashing', () => {
     expect(wrapper).toBeDefined()
-  });
+  })
 
   describe('Events > MapLabel', function () {
     describe('onMouseEnter', function () {
-      it('should trigger onHover and onActivate', function () {
+      it('should show image thumbnail onHover', function () {
         wrapper.find(StyledAnchor).first().simulate('mouseenter')
-        expect(onActivateSpy).toHaveBeenCalledWith(location)
-        expect(wrapper.find(StyledHr).length).toBe(1)
+        expect(wrapper.find(StyledImage).length).toBe(1)
       })
-    })
 
-    describe('onMouseLeave', function () {
-      it('should trigger onHover and onActivate', function () {
+      it('should not show image thumbnail onLeave', function () {
         wrapper.find(StyledAnchor).first().simulate('mouseleave')
-        expect(onActivateSpy).toHaveBeenCalledWith(null)
-        expect(wrapper.find(StyledHr).length).toBe(0)
+        expect(wrapper.find(StyledImage).length).toBe(0)
       })
     })
   })


### PR DESCRIPTION
This PR refactors the styling of the project home page to be responsive to tablet and mobile phone screens.

- Refactored the location anchor with image thumbnail hover effect
- Removed the location anchor hover effect from mobile widths
- Refactored various fixed `Box` dimensions

![desktop](https://user-images.githubusercontent.com/23665803/114627352-bdd92580-9c7a-11eb-881e-a33bcfaca1d6.jpg)

![mobile](https://user-images.githubusercontent.com/23665803/114627407-d2b5b900-9c7a-11eb-9c25-a106fb7235bd.jpg)
