### PR TITLE
Bug fix for DrawingOverlay coordinates after window resize

### DIFF
--- a/src/helpers/getRectBounds.js
+++ b/src/helpers/getRectBounds.js
@@ -15,9 +15,9 @@ export function getAspectSize(rectangle) {
 export default function getRectBounds(mapRef, rectangle) {
     const aspectSize = getAspectSize(rectangle)
 
-    let map = mapRef.current.leafletElement
-    let northEast = map.containerPointToLatLng({ x: rectangle.x + rectangle.width, y: rectangle.y})
-    let southWest = map.containerPointToLatLng({ x: rectangle.x, y: rectangle.y + rectangle.height })
+    let map = mapRef?.current?.leafletElement
+    let northEast = map?.containerPointToLatLng({ x: rectangle.x + rectangle.width, y: rectangle.y})
+    let southWest = map?.containerPointToLatLng({ x: rectangle.x, y: rectangle.y + rectangle.height })
 
     return { northEast, southWest, ...aspectSize }
 }

--- a/src/helpers/getRectBounds.js
+++ b/src/helpers/getRectBounds.js
@@ -15,9 +15,9 @@ export function getAspectSize(rectangle) {
 export default function getRectBounds(mapRef, rectangle) {
     const aspectSize = getAspectSize(rectangle)
 
-    let map = mapRef?.current?.leafletElement
-    let northEast = map?.layerPointToLatLng({ x: rectangle.x + rectangle.width, y: rectangle.y})
-    let southWest = map?.layerPointToLatLng({ x: rectangle.x, y: rectangle.y + rectangle.height })
+    let map = mapRef.current.leafletElement
+    let northEast = map.containerPointToLatLng({ x: rectangle.x + rectangle.width, y: rectangle.y})
+    let southWest = map.containerPointToLatLng({ x: rectangle.x, y: rectangle.y + rectangle.height })
 
     return { northEast, southWest, ...aspectSize }
 }

--- a/src/helpers/getRectBounds.spec.js
+++ b/src/helpers/getRectBounds.spec.js
@@ -5,7 +5,7 @@ let mockCoords = { lat: 100, lon: 100 }
 const mapRef = {
   current: {
     leafletElement: {
-      layerPointToLatLng: () => mockCoords
+      containerPointToLatLng: () => mockCoords
     }
   }
 }


### PR DESCRIPTION
Replaced `leaflet`'s method for converting (x, y) points to earth coordinates when a user draws a rectangle. 

I recommend making a selection over the town Stanley at different window sizes to test if the MapDetail modal shows the correct earth location.

![stanley](https://user-images.githubusercontent.com/23665803/115462695-92ad8380-a1f0-11eb-8696-81787317ba9b.jpg)
