### PR TITLE
Add CRA env to config.js

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,3 +36,6 @@ Launches the Storybook viewer at [http://localhost:9009/](http://localhost:9009/
 Uses [source-map-explorer](https://www.npmjs.com/package/source-map-explorer) to visually analyze the bundle for bloats.  
 To run this:
 `yarn build && yarn analyze`
+
+## Deployment
+

--- a/src/config.js
+++ b/src/config.js
@@ -1,7 +1,8 @@
 const DEFAULT_ENV = 'development';
 const envFromBrowser = locationMatch(/\W?env=(\w+)/);
+const envFromCreateReactApp = process.env.REACT_APP_ENV;
 const envFromShell = process.env.NODE_ENV;
-const env = envFromBrowser || envFromShell || DEFAULT_ENV;
+const env = envFromBrowser || envFromCreateReactApp || envFromShell || DEFAULT_ENV;
 
 if (!env.match(/^(production|staging|development|test)$/)) {
   throw new Error(`Error: Invalid Environment - ${env}`);


### PR DESCRIPTION
This PR adds REACT_APP_ENV to config.js in preparation for deploying a staging site. We want the mapping-viz-tools staging site to fetch data from mapping-viz-functions's staging database, and mapping-viz-tools production site to fetch data from mapping-viz-functions's production database.

This is a similar solution to alice, as documented here: https://github.com/zooniverse/alice#environment-variables