### PR TITLE
Add react-router-dom Link to Home

### DIFF
--- a/src/screens/Home/components/ChooseLocation/components/MapLabel.js
+++ b/src/screens/Home/components/ChooseLocation/components/MapLabel.js
@@ -1,13 +1,13 @@
 import React from 'react'
-import { Anchor, Box, Image } from 'grommet'
+import { Box, Image } from 'grommet'
 import styled, { css, withTheme } from 'styled-components'
 import { shape, string } from 'prop-types'
 import { withResponsiveContext } from '@zooniverse/react-components'
+import { Link } from 'react-router-dom'
 
-export const StyledAnchor = styled(Anchor)`
+export const LinkStyle = styled(Box)`
   white-space: nowrap;
   position: relative;
-  text-decoration: none;
 
   &::after {
     content: '';
@@ -66,7 +66,7 @@ export const StyledImage = styled(Image)`
     `}
 `
 
-const MapLabel = ({ location, screenSize }) => {
+const MapLabel = ({ location, screenSize, theme }) => {
   const mobile = screenSize === 'small'
 
   const [isHovered, onHover] = React.useState(false)
@@ -82,14 +82,19 @@ const MapLabel = ({ location, screenSize }) => {
 
   return (
     <Relative direction='row' margin={{ bottom: 'xsmall' }} mobile={mobile}>
-      <StyledAnchor
-        href='/map'
-        label={location.label}
+      <LinkStyle
         onBlur={deactivate}
         onFocus={activate}
         onMouseEnter={activate}
         onMouseLeave={deactivate}
-      />
+      >
+        <Link
+          to='/map'
+          style={{ color: theme.global.colors.brand, textDecoration: 'none' }}
+        >
+          {location.label}
+        </Link>
+      </LinkStyle>
       {isHovered && !mobile && (
         <Thumbnail>
           <StyledImage

--- a/src/screens/Home/components/ChooseLocation/components/MapLabel.spec.js
+++ b/src/screens/Home/components/ChooseLocation/components/MapLabel.spec.js
@@ -1,8 +1,10 @@
 import React from 'react'
 import { mount } from 'enzyme'
-import { MapLabel, StyledAnchor, StyledImage } from './MapLabel'
+import { MapLabel, LinkStyle, StyledImage } from './MapLabel'
 import theme from '../../../../../theme'
 import { Grommet } from 'grommet'
+import { Router } from 'react-router-dom'
+import history from '../../../../../history'
 
 let wrapper
 
@@ -13,10 +15,13 @@ describe('Component > MapLabel', function () {
   }
 
   beforeEach(function () {
-    wrapper = mount(<MapLabel location={location} />, {
-      wrappingComponent: Grommet,
-      wrappingComponentProps: { theme: theme },
-    })
+    wrapper = mount(
+      <Router history={history}>
+        <Grommet theme={theme}>
+          <MapLabel location={location} theme={theme} />
+        </Grommet>
+      </Router>
+    )
   })
 
   it('should render without crashing', () => {
@@ -26,12 +31,12 @@ describe('Component > MapLabel', function () {
   describe('Events > MapLabel', function () {
     describe('onMouseEnter', function () {
       it('should show image thumbnail onHover', function () {
-        wrapper.find(StyledAnchor).first().simulate('mouseenter')
+        wrapper.find(LinkStyle).first().simulate('mouseenter')
         expect(wrapper.find(StyledImage).length).toBe(1)
       })
 
       it('should not show image thumbnail onLeave', function () {
-        wrapper.find(StyledAnchor).first().simulate('mouseleave')
+        wrapper.find(LinkStyle).first().simulate('mouseleave')
         expect(wrapper.find(StyledImage).length).toBe(0)
       })
     })

--- a/src/screens/Home/components/ChooseLocation/theme.js
+++ b/src/screens/Home/components/ChooseLocation/theme.js
@@ -2,6 +2,11 @@ const theme = {
   anchor: {
     color: 'black',
     fontWeight: 300
+  },
+  global: {
+    colors: {
+      brand: '#000000'
+    }
   }
 }
 


### PR DESCRIPTION
This PR uses a Link component from react-router-dom on the homepage instead of a Grommet anchor to /map.