### PR TITLE
Build with Node 18 (lts/hydrogen)

### DIFF
--- a/.github/workflows/deploy_staging.yml
+++ b/.github/workflows/deploy_staging.yml
@@ -15,15 +15,13 @@ jobs:
     env:
       HEAD_COMMIT: ${{ github.sha }}
     steps:
-    - uses: actions/checkout@v2
-    - uses: azure/login@v1
-      with:
-          creds: ${{ secrets.AZURE_STATIC_SITES }}
+    - uses: actions/checkout@v3
 
     - name: Node.js build
-      uses: actions/setup-node@v1
+      uses: actions/setup-node@v3
       with:
-        node-version: '16.x'
+        node-version: 'lts/hydrogen'
+        cache: 'yarn'
     - run: yarn install --frozen-lockfile
     - run: yarn build
       env:
@@ -33,7 +31,7 @@ jobs:
       run: echo ${HEAD_COMMIT} > ./build/commit_id.txt
 
     - name: Save build
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       with:
         name: build
         path: ./build/

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -11,11 +11,13 @@ jobs:
   run_tests:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
 
     - name: Node.js build
-      uses: actions/setup-node@v1
+      uses: actions/setup-node@v3
       with:
-        node-version: '16.x'
+        node-version: 'lts/hydrogen'
+        cache: 'yarn'
     - run: yarn install
     - run: yarn test
+    - run: yarn build

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "license": "Apache-2.0",
   "engines": {
-    "node": ">=16"
+    "node": ">=18"
   },
   "dependencies": {
     "@fortawesome/fontawesome-svg-core": "^6.2.1",


### PR DESCRIPTION
- update `package.json`.
- update GitHub workflows.

Node 16 entered maintenance mode in October 2022 and support ends in September 2023.

GitHub Actions that run on Node 12 are also updated here. 